### PR TITLE
Cassandra debug writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ cassandra/data_files/
 
 # data files
 *.csv
+.vscode/launch.json

--- a/cassandra/transactions/t1.py
+++ b/cassandra/transactions/t1.py
@@ -8,300 +8,300 @@ from datetime import datetime
 # from testing, if stdin in consumed here, it will not be consumed in main.
 # returns list of (OL_I_ID, OL_SUPPLY_W_ID, OL_QUANTITY)
 def get_items(num_items):
-  items = []
-  for _ in range(num_items):
-    items.append(tuple(map(int, input().split(','))))
-  return items
+    items = []
+    for _ in range(num_items):
+        items.append(tuple(map(int, input().split(','))))
+    return items
 
 def execute_t1(session, args_arr):
-  print("T1 New Order Transaction called!")
+    print("T1 New Order Transaction called!")
 
-  ####################### extract query inputs    
-  assert len(args_arr) == 5, "Wrong length of argments for T1"
-  c_id = int(args_arr[1])
-  w_id = int(args_arr[2])
-  d_id = int(args_arr[3])
-  num_items = int(args_arr[4])
-  items = get_items(num_items)
+    ####################### extract query inputs    
+    assert len(args_arr) == 5, "Wrong length of argments for T1"
+    c_id = int(args_arr[1])
+    w_id = int(args_arr[2])
+    d_id = int(args_arr[3])
+    num_items = int(args_arr[4])
+    items = get_items(num_items)
 
-  districts = session.execute(f"""SELECT * FROM district WHERE d_w_id={w_id} AND d_id={d_id};""")
-  if not districts:
-    return 1
-  district = districts[0]
-  next_o_id = district.d_next_o_id
+    districts = session.execute(f"""SELECT * FROM district WHERE d_w_id={w_id} AND d_id={d_id};""")
+    if not districts:
+        return 1
+    district = districts[0]
+    next_o_id = district.d_next_o_id
 
-  session.execute(f"""UPDATE district SET D_NEXT_O_ID={next_o_id + 1} WHERE d_w_id={w_id} AND d_id={d_id}""")
+    session.execute(f"""UPDATE district SET D_NEXT_O_ID={next_o_id + 1} WHERE d_w_id={w_id} AND d_id={d_id}""")
 
-  # check if next_o_id updated
-  # district = session.execute(f"""SELECT * FROM district WHERE d_w_id={w_id} AND d_id={d_id}""")
-  # print(district[0])
+    # check if next_o_id updated
+    # district = session.execute(f"""SELECT * FROM district WHERE d_w_id={w_id} AND d_id={d_id}""")
+    # print(district[0])
 
-  customers = session.execute(f"""SELECT * FROM customer WHERE C_W_ID={w_id} AND C_D_ID={d_id} AND C_ID={c_id};""")
-  if not customers:
-    return 1
-  customer = customers[0]
+    customers = session.execute(f"""SELECT * FROM customer WHERE C_W_ID={w_id} AND C_D_ID={d_id} AND C_ID={c_id};""")
+    if not customers:
+        return 1
+    customer = customers[0]
 
-  is_all_local = len(list(filter(lambda tw: tw != w_id, [t[1] for t in items]))) == 0
+    is_all_local = len(list(filter(lambda tw: tw != w_id, [t[1] for t in items]))) == 0
 
-  ### create new order in both order tables
-  # strictly speaking, since they are not executed in batch, the O_ENTRY_D = toTimestamp(Now())
-  # will differ slightly for the 2 orders, but there don't seem to be any queries sensitive to 
-  # that timestamp, so leaving it as un-batched.
-  session.execute(
-  """INSERT INTO orders (
-                      o_w_id,
-                      o_d_id,
-                      o_carrier_id,
-                      o_id,
-                      o_c_id,
-                      o_all_local,
-                      o_c_first,
-                      o_c_last,
-                      o_c_middle,
-                      o_entry_d,
-                      o_ol_cnt) 
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()), %s);""", 
-                      (
-                      w_id,
-                      d_id,
-                      -1,
-                      next_o_id,
-                      c_id,
-                      (1 if is_all_local else 0),
-                      customer.c_first,
-                      customer.c_last,
-                      customer.c_middle,
-                      num_items
-                      ))
-  session.execute(
-  """INSERT INTO order_by_carrier_id (
-                      o_w_id,
-                      o_d_id,
-                      o_carrier_id,
-                      o_id,
-                      o_c_id,
-                      o_all_local,
-                      o_c_first,
-                      o_c_last,
-                      o_c_middle,
-                      o_entry_d,
-                      o_ol_cnt) 
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()), %s);""", 
-                      (
-                      w_id,
-                      d_id,
-                      -1,
-                      next_o_id,
-                      c_id,
-                      (1 if is_all_local else 0),
-                      customer.c_first,
-                      customer.c_last,
-                      customer.c_middle,
-                      num_items
-                      ))
+    ### create new order in both order tables
+    # strictly speaking, since they are not executed in batch, the O_ENTRY_D = toTimestamp(Now())
+    # will differ slightly for the 2 orders, but there don't seem to be any queries sensitive to 
+    # that timestamp, so leaving it as un-batched.
+    session.execute(
+        """INSERT INTO orders (
+                            o_w_id,
+                            o_d_id,
+                            o_carrier_id,
+                            o_id,
+                            o_c_id,
+                            o_all_local,
+                            o_c_first,
+                            o_c_last,
+                            o_c_middle,
+                            o_entry_d,
+                            o_ol_cnt) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()), %s);""", 
+                            (
+                            w_id,
+                            d_id,
+                            -1,
+                            next_o_id,
+                            c_id,
+                            (1 if is_all_local else 0),
+                            customer.c_first,
+                            customer.c_last,
+                            customer.c_middle,
+                            num_items
+                            ))
+    session.execute(
+        """INSERT INTO order_by_carrier_id (
+                            o_w_id,
+                            o_d_id,
+                            o_carrier_id,
+                            o_id,
+                            o_c_id,
+                            o_all_local,
+                            o_c_first,
+                            o_c_last,
+                            o_c_middle,
+                            o_entry_d,
+                            o_ol_cnt) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()), %s);""", 
+                            (
+                            w_id,
+                            d_id,
+                            -1,
+                            next_o_id,
+                            c_id,
+                            (1 if is_all_local else 0),
+                            customer.c_first,
+                            customer.c_last,
+                            customer.c_middle,
+                            num_items
+                            ))
 
-  total_amount = 0
-  item_names = []     #for printing later
-  item_amounts = []   #for printing later
-  remaining_qtys = [] #for printing later
+    total_amount = 0
+    item_names = []     #for printing later
+    item_amounts = []   #for printing later
+    remaining_qtys = [] #for printing later
 
-  for i, tup in enumerate(items):
-    ol_i_id, ol_supply_w_id, ol_quantity = tup
+    for i, tup in enumerate(items):
+        ol_i_id, ol_supply_w_id, ol_quantity = tup
 
-    stocks = session.execute(f"""SELECT * FROM stock WHERE S_W_ID={ol_supply_w_id} AND S_I_ID={ol_i_id};""")
-    if not stocks:
-      return 1
-    stock = stocks[0]
-    # print(stock)
-    
-    s_qty = stock.s_quantity
-    adj_qty = s_qty - ol_quantity
-    if adj_qty < 10:
-      adj_qty += 100
-    remaining_qtys.append(adj_qty)
+        stocks = session.execute(f"""SELECT * FROM stock WHERE S_W_ID={ol_supply_w_id} AND S_I_ID={ol_i_id};""")
+        if not stocks:
+            return 1
+        stock = stocks[0]
+        # print(stock)
+        
+        s_qty = stock.s_quantity
+        adj_qty = s_qty - ol_quantity
+        if adj_qty < 10:
+            adj_qty += 100
+        remaining_qtys.append(adj_qty)
 
-    # with addition of S_QUANTITY to PK of stock, must delete and reinsert to update
-    ts = int(time.time() * 10e6)
-    batch = BatchStatement()
-    batch.add(SimpleStatement(f"""
-      DELETE from stock 
-      USING TIMESTAMP {ts}
-      WHERE s_w_id=%s
-      AND s_i_id=%s
-      AND s_quantity=%s;
-    """), (ol_supply_w_id, ol_i_id, stock.s_quantity))
+        # with addition of S_QUANTITY to PK of stock, must delete and reinsert to update
+        ts = int(time.time() * 10e6)
+        batch = BatchStatement()
+        batch.add(SimpleStatement(f"""
+            DELETE from stock 
+            USING TIMESTAMP {ts}
+            WHERE s_w_id=%s
+            AND s_i_id=%s
+            AND s_quantity=%s;
+            """), (ol_supply_w_id, ol_i_id, stock.s_quantity))
 
-    batch.add(SimpleStatement(f"""
-      INSERT INTO stock (
-        S_W_ID,
-        S_I_ID,
-        S_QUANTITY,
-        S_YTD,
-        S_ORDER_CNT,
-        S_REMOTE_CNT,
-        S_DIST_01,
-        S_DIST_02,
-        S_DIST_03,
-        S_DIST_04,
-        S_DIST_05,
-        S_DIST_06,
-        S_DIST_07,
-        S_DIST_08,
-        S_DIST_09,
-        S_DIST_10,
-        S_DATA
-      ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-      USING TIMESTAMP %s;"""), 
-      (
-        stock.s_w_id,
-        stock.s_i_id,
-        adj_qty,
-        stock.s_ytd + ol_quantity,
-        stock.s_order_cnt + 1,
-        stock.s_remote_cnt + (1 if ol_supply_w_id != w_id else 0),
-        stock.s_dist_01,
-        stock.s_dist_02,
-        stock.s_dist_03,
-        stock.s_dist_04,
-        stock.s_dist_05,
-        stock.s_dist_06,
-        stock.s_dist_07,
-        stock.s_dist_08,
-        stock.s_dist_09,
-        stock.s_dist_10,
-        stock.s_data,
-        ts + 1
-      ))
-    session.execute(batch)
-    
+        batch.add(SimpleStatement(f"""
+            INSERT INTO stock (
+                S_W_ID,
+                S_I_ID,
+                S_QUANTITY,
+                S_YTD,
+                S_ORDER_CNT,
+                S_REMOTE_CNT,
+                S_DIST_01,
+                S_DIST_02,
+                S_DIST_03,
+                S_DIST_04,
+                S_DIST_05,
+                S_DIST_06,
+                S_DIST_07,
+                S_DIST_08,
+                S_DIST_09,
+                S_DIST_10,
+                S_DATA
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            USING TIMESTAMP %s;"""), 
+            (
+                stock.s_w_id,
+                stock.s_i_id,
+                adj_qty,
+                stock.s_ytd + ol_quantity,
+                stock.s_order_cnt + 1,
+                stock.s_remote_cnt + (1 if ol_supply_w_id != w_id else 0),
+                stock.s_dist_01,
+                stock.s_dist_02,
+                stock.s_dist_03,
+                stock.s_dist_04,
+                stock.s_dist_05,
+                stock.s_dist_06,
+                stock.s_dist_07,
+                stock.s_dist_08,
+                stock.s_dist_09,
+                stock.s_dist_10,
+                stock.s_data,
+                ts + 1
+            ))
+        session.execute(batch)
+        
 
-    item_infos = session.execute(f"""SELECT * FROM item WHERE i_id={ol_i_id}""")
-    if not item_infos:
-      return 1
-    item_info = item_infos[0]
-    price = item_info.i_price
-    item_amount = ol_quantity * price
-    total_amount += item_amount
+        item_infos = session.execute(f"""SELECT * FROM item WHERE i_id={ol_i_id}""")
+        if not item_infos:
+            return 1
+        item_info = item_infos[0]
+        price = item_info.i_price
+        item_amount = ol_quantity * price
+        total_amount += item_amount
 
-    item_names.append(item_info.i_name)
-    item_amounts.append(item_amount)
+        item_names.append(item_info.i_name)
+        item_amounts.append(item_amount)
 
-    # note: OL_DELIVERY_D needs to be created with null here (T1), set in T3, and queried
-    # in T4. So we DON'T insert OL_DELIVERY_D for an implicit null (col doesn't exist).
-    # Don't need special null value bc we are not querying "WHERE OL_DELIVERY_D IS NULL"
+        # note: OL_DELIVERY_D needs to be created with null here (T1), set in T3, and queried
+        # in T4. So we DON'T insert OL_DELIVERY_D for an implicit null (col doesn't exist).
+        # Don't need special null value bc we are not querying "WHERE OL_DELIVERY_D IS NULL"
 
-    # print(f'insert into orderline',w_id, d_id,next_o_id,i+1)
-    session.execute("""
-      INSERT INTO order_line (
-            OL_W_ID,
-            OL_D_ID,
-            OL_O_ID,
-            OL_NUMBER,
-            OL_I_ID,
-            OL_AMOUNT,
-            OL_SUPPLY_W_ID,
-            OL_QUANTITY,
-            OL_DIST_INFO,
-            OL_I_NAME,
-            OL_I_PRICE,
-            OL_C_ID,
-            OL_C_FIRST,
-            OL_C_MIDDLE,
-            OL_C_LAST,
-            OL_O_ENTRY_D
-          ) 
-      VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()));""", 
-        (
-          w_id,
-          d_id,
-          next_o_id,
-          i+1, #1-based indexing
-          ol_i_id,
-          item_amount,
-          ol_supply_w_id,
-          ol_quantity,
-          stock[2 + d_id],  # note: if schema of stocks changes, the index of S_DIST_XX will change too!
-          item_info.i_name,
-          item_info.i_price,
-          c_id,
-          customer.c_first,
-          customer.c_last,
-          customer.c_middle,
-        ))
-    
-    # Create new order_line in 3 duplicate order_line tables too.
-    session.execute("""
-      INSERT INTO order_line_by_customer (
-        OL_W_ID,
-        OL_D_ID,
-        OL_O_ID,
-        OL_NUMBER,
-        OL_I_ID,
-        OL_C_ID
-      ) VALUES (%s, %s, %s, %s, %s, %s);""",
-      (
-        w_id,
-        d_id,
-        next_o_id,
-        i+1, #1-based indexing
-        ol_i_id,
-        c_id
-      ))
-    session.execute("""
-      INSERT INTO order_line_by_item (
-        OL_W_ID,
-        OL_D_ID,
-        OL_O_ID,
-        OL_NUMBER,
-        OL_I_ID,
-        OL_C_ID
-      ) VALUES (%s, %s, %s, %s, %s, %s);""",
-      (
-        w_id,
-        d_id,
-        next_o_id,
-        i+1, #1-based indexing
-        ol_i_id,
-        c_id
-      ))
-    session.execute("""
-      INSERT INTO order_line_by_order (
-        OL_W_ID,
-        OL_D_ID,
-        OL_O_ID,
-        OL_NUMBER,
-        OL_I_ID,
-        OL_C_ID
-      ) VALUES (%s, %s, %s, %s, %s, %s);""",
-      (
-        w_id,
-        d_id,
-        next_o_id,
-        i+1, #1-based indexing
-        ol_i_id,
-        c_id
-      ))
+        # print(f'insert into orderline',w_id, d_id,next_o_id,i+1)
+        session.execute("""
+            INSERT INTO order_line (
+                    OL_W_ID,
+                    OL_D_ID,
+                    OL_O_ID,
+                    OL_NUMBER,
+                    OL_I_ID,
+                    OL_AMOUNT,
+                    OL_SUPPLY_W_ID,
+                    OL_QUANTITY,
+                    OL_DIST_INFO,
+                    OL_I_NAME,
+                    OL_I_PRICE,
+                    OL_C_ID,
+                    OL_C_FIRST,
+                    OL_C_MIDDLE,
+                    OL_C_LAST,
+                    OL_O_ENTRY_D
+                ) 
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, toTimestamp(Now()));""", 
+                (
+                w_id,
+                d_id,
+                next_o_id,
+                i+1, #1-based indexing
+                ol_i_id,
+                item_amount,
+                ol_supply_w_id,
+                ol_quantity,
+                stock[2 + d_id],  # note: if schema of stocks changes, the index of S_DIST_XX will change too!
+                item_info.i_name,
+                item_info.i_price,
+                c_id,
+                customer.c_first,
+                customer.c_last,
+                customer.c_middle,
+                ))
+        
+        # Create new order_line in 3 duplicate order_line tables too.
+        session.execute("""
+            INSERT INTO order_line_by_customer (
+                OL_W_ID,
+                OL_D_ID,
+                OL_O_ID,
+                OL_NUMBER,
+                OL_I_ID,
+                OL_C_ID
+            ) VALUES (%s, %s, %s, %s, %s, %s);""",
+            (
+                w_id,
+                d_id,
+                next_o_id,
+                i+1, #1-based indexing
+                ol_i_id,
+                c_id
+            ))
+        session.execute("""
+            INSERT INTO order_line_by_item (
+                OL_W_ID,
+                OL_D_ID,
+                OL_O_ID,
+                OL_NUMBER,
+                OL_I_ID,
+                OL_C_ID
+            ) VALUES (%s, %s, %s, %s, %s, %s);""",
+            (
+                w_id,
+                d_id,
+                next_o_id,
+                i+1, #1-based indexing
+                ol_i_id,
+                c_id
+            ))
+        session.execute("""
+            INSERT INTO order_line_by_order (
+                OL_W_ID,
+                OL_D_ID,
+                OL_O_ID,
+                OL_NUMBER,
+                OL_I_ID,
+                OL_C_ID
+            ) VALUES (%s, %s, %s, %s, %s, %s);""",
+            (
+                w_id,
+                d_id,
+                next_o_id,
+                i+1, #1-based indexing
+                ol_i_id,
+                c_id
+            ))
   
-  # print('bef', total_amount)
-  d_tax = district.d_tax
-  warehouses = session.execute(f"""SELECT * FROM warehouse WHERE w_id={w_id}""")
-  if not warehouses:
-    return 1
-  warehouse = warehouses[0]
-  w_tax = warehouse.w_tax
-  total_amount *= (1 + d_tax + w_tax) * (1 - customer.c_discount)
-  # print(d_tax)
-  # print(w_tax)
-  # print(customer.c_discount)
-  # print('aft:', total_amount)
+    # print('bef', total_amount)
+    d_tax = district.d_tax
+    warehouses = session.execute(f"""SELECT * FROM warehouse WHERE w_id={w_id}""")
+    if not warehouses:
+        return 1
+    warehouse = warehouses[0]
+    w_tax = warehouse.w_tax
+    total_amount *= (1 + d_tax + w_tax) * (1 - customer.c_discount)
+    # print(d_tax)
+    # print(w_tax)
+    # print(customer.c_discount)
+    # print('aft:', total_amount)
 
-  #### print out required info
-  print(customer.c_w_id, customer.c_d_id, customer.c_id, customer.c_last, customer.c_credit, customer.c_discount)
-  print(w_tax, d_tax)
-  print(next_o_id, datetime.now())  #current timestamp separate from query's ts so we don't query it again
-  print(num_items, total_amount)
-  for i in range(num_items):
-    print(items[i][0], item_names[i], items[i][1], items[i][2], item_amounts[i], remaining_qtys[i])
-  
-  return 0
+    #### print out required info
+    print(customer.c_w_id, customer.c_d_id, customer.c_id, customer.c_last, customer.c_credit, customer.c_discount)
+    print(w_tax, d_tax)
+    print(next_o_id, datetime.now())  #current timestamp separate from query's ts so we don't query it again
+    print(num_items, total_amount)
+    for i in range(num_items):
+        print(items[i][0], item_names[i], items[i][1], items[i][2], item_amounts[i], remaining_qtys[i])
+
+    return 0
 

--- a/cassandra/transactions/t1.py
+++ b/cassandra/transactions/t1.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from cassandra.query import BatchStatement, SimpleStatement
 from decimal import Decimal
 from datetime import datetime
@@ -120,9 +121,11 @@ def execute_t1(session, args_arr):
     remaining_qtys.append(adj_qty)
 
     # with addition of S_QUANTITY to PK of stock, must delete and reinsert to update
+    ts = int(time.time() * 10e6)
     batch = BatchStatement()
     batch.add(SimpleStatement(f"""
       DELETE from stock 
+      USING TIMESTAMP {ts}
       WHERE s_w_id=%s
       AND s_i_id=%s
       AND s_quantity=%s;
@@ -147,7 +150,8 @@ def execute_t1(session, args_arr):
         S_DIST_09,
         S_DIST_10,
         S_DATA
-      ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s);"""), 
+      ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+      USING TIMESTAMP %s;"""), 
       (
         stock.s_w_id,
         stock.s_i_id,
@@ -165,7 +169,8 @@ def execute_t1(session, args_arr):
         stock.s_dist_08,
         stock.s_dist_09,
         stock.s_dist_10,
-        stock.s_data
+        stock.s_data,
+        ts + 1
       ))
     session.execute(batch)
     

--- a/cassandra/transactions/t2.py
+++ b/cassandra/transactions/t2.py
@@ -37,10 +37,7 @@ def execute_t2(session, args_arr):
     upd_warehouse = SimpleStatement(f"""UPDATE warehouse SET w_ytd={ret_warehouse.w_ytd + payment} 
                                         WHERE w_id={c_w_id};""")
 
-    response = session.execute(upd_warehouse)
-    if not response:
-      # update failed, silently returning
-      return 1
+    session.execute(upd_warehouse)
 
     upd_district = SimpleStatement(f"""UPDATE district SET d_ytd={ret_district.d_ytd + payment} 
                                     WHERE d_w_id={c_w_id} AND d_id={c_d_id};""")

--- a/cassandra/transactions/t2.py
+++ b/cassandra/transactions/t2.py
@@ -47,63 +47,63 @@ def execute_t2(session, args_arr):
     ts = int(time.time() * 10e6)
     batch = BatchStatement()
     batch.add(SimpleStatement(f"""
-      DELETE FROM customer 
-      USING TIMESTAMP {ts}
-      WHERE c_w_id={c_w_id} 
-      and c_d_id={c_d_id} 
-      and c_id={c_id};"""))
+        DELETE FROM customer 
+        USING TIMESTAMP {ts}
+        WHERE c_w_id={c_w_id} 
+        and c_d_id={c_d_id} 
+        and c_id={c_id};"""))
 
     batch.add(SimpleStatement(f"""
-    INSERT INTO customer (c_w_id, 
-                          c_d_id, 
-                          c_id, 
-                          c_balance, 
-                          c_city, 
-                          c_credit, 
-                          c_credit_lim, 
-                          c_d_name, 
-                          c_data, 
-                          c_delivery_cnt,
-                          c_discount,
-                          c_first,
-                          c_last,
-                          c_middle,
-                          c_payment_cnt,
-                          c_phone,
-                          c_since,
-                          c_state,
-                          c_street_1,
-                          c_street_2,
-                          c_w_name,
-                          c_ytd_payment,
-                          c_zip) 
-                  VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                  USING TIMESTAMP %s;"""), 
-                          (ret_customer.c_w_id, 
-                          ret_customer.c_d_id, 
-                          ret_customer.c_id, 
-                          ret_customer.c_balance - payment, 
-                          ret_customer.c_city, 
-                          ret_customer.c_credit, 
-                          ret_customer.c_credit_lim, 
-                          ret_customer.c_d_name, 
-                          ret_customer.c_data, 
-                          ret_customer.c_delivery_cnt,
-                          ret_customer.c_discount,
-                          ret_customer.c_first,
-                          ret_customer.c_last,
-                          ret_customer.c_middle,
-                          ret_customer.c_payment_cnt + 1,
-                          ret_customer.c_phone,
-                          ret_customer.c_since,
-                          ret_customer.c_state,
-                          ret_customer.c_street_1,
-                          ret_customer.c_street_2,
-                          ret_customer.c_w_name,
-                          ret_customer.c_ytd_payment + float(payment),
-                          ret_customer.c_zip,
-                          ts + 1 # so that this stmt is ran after the DELETE in this batch
-                          ))
+        INSERT INTO customer (c_w_id, 
+                            c_d_id, 
+                            c_id, 
+                            c_balance, 
+                            c_city, 
+                            c_credit, 
+                            c_credit_lim, 
+                            c_d_name, 
+                            c_data, 
+                            c_delivery_cnt,
+                            c_discount,
+                            c_first,
+                            c_last,
+                            c_middle,
+                            c_payment_cnt,
+                            c_phone,
+                            c_since,
+                            c_state,
+                            c_street_1,
+                            c_street_2,
+                            c_w_name,
+                            c_ytd_payment,
+                            c_zip) 
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    USING TIMESTAMP %s;"""), 
+                            (ret_customer.c_w_id, 
+                            ret_customer.c_d_id, 
+                            ret_customer.c_id, 
+                            ret_customer.c_balance - payment, 
+                            ret_customer.c_city, 
+                            ret_customer.c_credit, 
+                            ret_customer.c_credit_lim, 
+                            ret_customer.c_d_name, 
+                            ret_customer.c_data, 
+                            ret_customer.c_delivery_cnt,
+                            ret_customer.c_discount,
+                            ret_customer.c_first,
+                            ret_customer.c_last,
+                            ret_customer.c_middle,
+                            ret_customer.c_payment_cnt + 1,
+                            ret_customer.c_phone,
+                            ret_customer.c_since,
+                            ret_customer.c_state,
+                            ret_customer.c_street_1,
+                            ret_customer.c_street_2,
+                            ret_customer.c_w_name,
+                            ret_customer.c_ytd_payment + float(payment),
+                            ret_customer.c_zip,
+                            ts + 1 # so that this stmt is ran after the DELETE in this batch
+                            ))
     
     session.execute(batch)
     
@@ -113,35 +113,35 @@ def execute_t2(session, args_arr):
     ts = int(time.time() * 10e6)
     batch = BatchStatement()
     batch.add(SimpleStatement(f"""
-      DELETE FROM top_balance 
-      USING TIMESTAMP {ts}
-      WHERE c_w_id={c_w_id} 
-      and c_d_id={c_d_id} 
-      and c_balance={ret_customer.c_balance} 
-      and c_id={c_id};"""))
+        DELETE FROM top_balance 
+        USING TIMESTAMP {ts}
+        WHERE c_w_id={c_w_id} 
+        and c_d_id={c_d_id} 
+        and c_balance={ret_customer.c_balance} 
+        and c_id={c_id};"""))
 
     batch.add(SimpleStatement(f"""
-      INSERT INTO top_balance (c_w_id,
-                                c_d_id,
-                                c_balance,
-                                c_id,
-                                c_d_name,
-                                c_first,
-                                c_last,
-                                c_middle,
-                                c_w_name) 
-                  VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-                  USING TIMESTAMP %s;"""), 
-                          (ret_customer.c_w_id, 
-                          ret_customer.c_d_id, 
-                          ret_customer.c_balance - payment, 
-                          ret_customer.c_id, 
-                          ret_customer.c_d_name, 
-                          ret_customer.c_first,
-                          ret_customer.c_last,
-                          ret_customer.c_middle,
-                          ret_customer.c_w_name,
-                          ts + 1))
+        INSERT INTO top_balance (c_w_id,
+                                    c_d_id,
+                                    c_balance,
+                                    c_id,
+                                    c_d_name,
+                                    c_first,
+                                    c_last,
+                                    c_middle,
+                                    c_w_name) 
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    USING TIMESTAMP %s;"""), 
+                            (ret_customer.c_w_id, 
+                            ret_customer.c_d_id, 
+                            ret_customer.c_balance - payment, 
+                            ret_customer.c_id, 
+                            ret_customer.c_d_name, 
+                            ret_customer.c_first,
+                            ret_customer.c_last,
+                            ret_customer.c_middle,
+                            ret_customer.c_w_name,
+                            ts + 1))
     session.execute(batch)
 
     # print required info; printing updated values

--- a/cassandra/transactions/t3.py
+++ b/cassandra/transactions/t3.py
@@ -20,291 +20,291 @@ def execute_t3(session, args_arr):
     return_code = 0 # default success
 
     for d_id in range(1, 11): # [1..10]
-      # Orders table: (o_w_id, o_d_id, o_id) uniquely identify row
-      # So given (o_w_id, o_d_id), each o_id returned should be unique
-      # Expect: bc of clustering, smallest o_id is first.
-      orders = session.execute(f"""
-        SELECT * FROM order_by_carrier_id WHERE o_w_id=%s and o_d_id=%s and o_carrier_id=%s LIMIT 1;""",
-        (w_id, d_id, -1))
-      if not orders:
-        # print(f'No null carrier_id exists for w={w_id}, d={d_id}, skipping to next district.')
-        # does not count as failed query bc could be that district has no orders with carrier_id == -1
-        continue
-      order = orders[0]
-      # print(order)
-
-      ##### update carrier_id in order_by_carrier_id, which is a PK col
-      ts = int(time.time() * 10e6)
-      batch = BatchStatement()
-      batch.add(SimpleStatement(f"""
-        DELETE FROM order_by_carrier_id 
-        USING TIMESTAMP {ts}
-        WHERE o_w_id={order.o_w_id} 
-          AND o_d_id={order.o_d_id} 
-          AND o_carrier_id={order.o_carrier_id} 
-          AND o_id={order.o_id} 
-          AND o_c_id={order.o_c_id};"""))
-
-      batch.add(SimpleStatement(f"""
-        INSERT INTO order_by_carrier_id (
-                            o_w_id,
-                            o_d_id,
-                            o_carrier_id,
-                            o_id,
-                            o_c_id,
-                            o_all_local,
-                            o_c_first,
-                            o_c_last,
-                            o_c_middle,
-                            o_entry_d,
-                            o_ol_cnt) 
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    USING TIMESTAMP %s;"""), 
-                         (order.o_w_id,
-                          order.o_d_id,
-                          new_carrier_id,
-                          order.o_id,
-                          order.o_c_id,
-                          order.o_all_local,
-                          order.o_c_first,
-                          order.o_c_last,
-                          order.o_c_middle,
-                          order.o_entry_d,
-                          order.o_ol_cnt,
-                          ts + 1))
-      
-      session.execute(batch)
-
-      #### check update of carrier_id is correct
-      # skipping check for benchmarking
-      # chk = session.execute(f"""
-      #   SELECT * FROM order_by_carrier_id 
-      #   WHERE o_w_id=%s 
-      #   and o_d_id=%s 
-      #   and o_carrier_id=%s 
-      #   and o_id=%s LIMIT 1;""",
-      #   (order.o_w_id, order.o_d_id, new_carrier_id, order.o_id))[0]
-      # print(chk)
-
-      ##### update carrier_id in orders, which is a PK col
-      ts = int(time.time() * 10e6)
-      batch = BatchStatement()
-      batch.add(SimpleStatement(f"""
-        DELETE FROM orders 
-        USING TIMESTAMP {ts}
-        WHERE o_w_id={order.o_w_id} 
-          AND o_d_id={order.o_d_id} 
-          AND o_id={order.o_id} 
-          AND o_c_id={order.o_c_id};"""))
-
-      batch.add(SimpleStatement(f"""
-        INSERT INTO orders (o_w_id,
-                            o_d_id,
-                            o_carrier_id,
-                            o_id,
-                            o_c_id,
-                            o_all_local,
-                            o_c_first,
-                            o_c_last,
-                            o_c_middle,
-                            o_entry_d,
-                            o_ol_cnt) 
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    USING TIMESTAMP %s;"""), 
-                         (order.o_w_id,
-                          order.o_d_id,
-                          new_carrier_id,
-                          order.o_id,
-                          order.o_c_id,
-                          order.o_all_local,
-                          order.o_c_first,
-                          order.o_c_last,
-                          order.o_c_middle,
-                          order.o_entry_d,
-                          order.o_ol_cnt,
-                          ts + 1))
-      session.execute(batch)      
-      
-      #### update order_line table
-      # when queried with (ol_w_id, ol_d_id, ol_o_id), each rows return should have unique ol_number
-      order_lines = session.execute(f"""
-          SELECT * FROM order_line WHERE ol_w_id=%s AND ol_d_id=%s AND ol_o_id=%s;""",
-          (w_id, d_id, order.o_id))
-      
-      if not order_lines:
-        return_code = 1
-        continue
-
-      # note: order_lines is an iterator and will be exhausted. Only one iteration is allowed without duplicating it.
-      ol_amount_total = Decimal(0)
-      none_ol_amount = False
-      for r in order_lines:
-        session.execute(f"""
-          UPDATE order_line 
-          SET ol_delivery_d=toTimestamp(Now())
-          WHERE OL_W_ID=%s 
-            AND OL_D_ID=%s
-            AND OL_O_ID=%s
-            AND OL_QUANTITY=%s
-            AND OL_NUMBER=%s
-            AND OL_C_ID=%s;""",
-          (r.ol_w_id, r.ol_d_id, r.ol_o_id, r.ol_quantity, r.ol_number, r.ol_c_id))
-
-        if r.ol_amount is None:
-            none_ol_amount = True
-            # try to update as many order_lines as possible
+        # Orders table: (o_w_id, o_d_id, o_id) uniquely identify row
+        # So given (o_w_id, o_d_id), each o_id returned should be unique
+        # Expect: bc of clustering, smallest o_id is first.
+        orders = session.execute(f"""
+            SELECT * FROM order_by_carrier_id WHERE o_w_id=%s and o_d_id=%s and o_carrier_id=%s LIMIT 1;""",
+            (w_id, d_id, -1))
+        if not orders:
+            # print(f'No null carrier_id exists for w={w_id}, d={d_id}, skipping to next district.')
+            # does not count as failed query bc could be that district has no orders with carrier_id == -1
             continue
-        ol_amount_total += r.ol_amount
+        order = orders[0]
+        # print(order)
 
+        ##### update carrier_id in order_by_carrier_id, which is a PK col
+        ts = int(time.time() * 10e6)
+        batch = BatchStatement()
+        batch.add(SimpleStatement(f"""
+            DELETE FROM order_by_carrier_id 
+            USING TIMESTAMP {ts}
+            WHERE o_w_id={order.o_w_id} 
+            AND o_d_id={order.o_d_id} 
+            AND o_carrier_id={order.o_carrier_id} 
+            AND o_id={order.o_id} 
+            AND o_c_id={order.o_c_id};"""))
 
-      if none_ol_amount:
-          return_code = 1
-          continue
+        batch.add(SimpleStatement(f"""
+            INSERT INTO order_by_carrier_id (
+                                o_w_id,
+                                o_d_id,
+                                o_carrier_id,
+                                o_id,
+                                o_c_id,
+                                o_all_local,
+                                o_c_first,
+                                o_c_last,
+                                o_c_middle,
+                                o_entry_d,
+                                o_ol_cnt) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        USING TIMESTAMP %s;"""), 
+                            (order.o_w_id,
+                            order.o_d_id,
+                            new_carrier_id,
+                            order.o_id,
+                            order.o_c_id,
+                            order.o_all_local,
+                            order.o_c_first,
+                            order.o_c_last,
+                            order.o_c_middle,
+                            order.o_entry_d,
+                            order.o_ol_cnt,
+                            ts + 1))
         
-      #### check order_lines correctly updated
-      # print()
-      # order_lines = session.execute(f"""
-      #   SELECT * FROM order_line WHERE ol_w_id=%s AND ol_d_id=%s AND ol_o_id=%s;""",
-      #   (w_id, d_id, order.o_id))
-      # for r in order_lines:
-      #   print(r)
+        session.execute(batch)
 
-      #### update customer's C_BALANCE, C_DELIVERY_CNT via drop and insert
-      # not expected to fail. `order` exists at this point.
-      customer = session.execute(SimpleStatement(f"""
-        SELECT * FROM customer 
-        WHERE c_w_id={w_id} 
-        and c_d_id={d_id} 
-        and c_id={order.o_c_id};"""))
-      if not customer:
-        return_code = 1
-        continue
-      customer = customer[0]
-      # print(customer)
+        #### check update of carrier_id is correct
+        # skipping check for benchmarking
+        # chk = session.execute(f"""
+        #   SELECT * FROM order_by_carrier_id 
+        #   WHERE o_w_id=%s 
+        #   and o_d_id=%s 
+        #   and o_carrier_id=%s 
+        #   and o_id=%s LIMIT 1;""",
+        #   (order.o_w_id, order.o_d_id, new_carrier_id, order.o_id))[0]
+        # print(chk)
 
-      ts = int(time.time() * 10e6)
-      batch = BatchStatement()
-      batch.add(SimpleStatement(f"""
-        DELETE FROM customer 
-        USING TIMESTAMP {ts}
-        WHERE c_w_id={w_id} 
-        and c_d_id={d_id} 
-        and c_id={order.o_c_id};"""))
+        ##### update carrier_id in orders, which is a PK col
+        ts = int(time.time() * 10e6)
+        batch = BatchStatement()
+        batch.add(SimpleStatement(f"""
+            DELETE FROM orders 
+            USING TIMESTAMP {ts}
+            WHERE o_w_id={order.o_w_id} 
+            AND o_d_id={order.o_d_id} 
+            AND o_id={order.o_id} 
+            AND o_c_id={order.o_c_id};"""))
 
-      batch.add(SimpleStatement(f"""
-        INSERT INTO customer (c_w_id, 
-                              c_d_id, 
-                              c_id, 
-                              c_balance, 
-                              c_city, 
-                              c_credit, 
-                              c_credit_lim, 
-                              c_d_name, 
-                              c_data, 
-                              c_delivery_cnt,
-                              c_discount,
-                              c_first,
-                              c_last,
-                              c_middle,
-                              c_payment_cnt,
-                              c_phone,
-                              c_since,
-                              c_state,
-                              c_street_1,
-                              c_street_2,
-                              c_w_name,
-                              c_ytd_payment,
-                              c_zip) 
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    USING TIMESTAMP %s;"""), 
-                           (customer.c_w_id, 
+        batch.add(SimpleStatement(f"""
+            INSERT INTO orders (o_w_id,
+                                o_d_id,
+                                o_carrier_id,
+                                o_id,
+                                o_c_id,
+                                o_all_local,
+                                o_c_first,
+                                o_c_last,
+                                o_c_middle,
+                                o_entry_d,
+                                o_ol_cnt) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        USING TIMESTAMP %s;"""), 
+                            (order.o_w_id,
+                            order.o_d_id,
+                            new_carrier_id,
+                            order.o_id,
+                            order.o_c_id,
+                            order.o_all_local,
+                            order.o_c_first,
+                            order.o_c_last,
+                            order.o_c_middle,
+                            order.o_entry_d,
+                            order.o_ol_cnt,
+                            ts + 1))
+        session.execute(batch)      
+      
+        #### update order_line table
+        # when queried with (ol_w_id, ol_d_id, ol_o_id), each rows return should have unique ol_number
+        order_lines = session.execute(f"""
+            SELECT * FROM order_line WHERE ol_w_id=%s AND ol_d_id=%s AND ol_o_id=%s;""",
+            (w_id, d_id, order.o_id))
+        
+        if not order_lines:
+            return_code = 1
+            continue
+
+        # note: order_lines is an iterator and will be exhausted. Only one iteration is allowed without duplicating it.
+        ol_amount_total = Decimal(0)
+        none_ol_amount = False
+        
+        for r in order_lines:
+            session.execute(f"""
+                UPDATE order_line 
+                SET ol_delivery_d=toTimestamp(Now())
+                WHERE OL_W_ID=%s 
+                    AND OL_D_ID=%s
+                    AND OL_O_ID=%s
+                    AND OL_QUANTITY=%s
+                    AND OL_NUMBER=%s
+                    AND OL_C_ID=%s;""",
+                (r.ol_w_id, r.ol_d_id, r.ol_o_id, r.ol_quantity, r.ol_number, r.ol_c_id))
+
+            if r.ol_amount is None:
+                none_ol_amount = True
+                # try to update as many order_lines as possible
+                continue
+            ol_amount_total += r.ol_amount
+
+        if none_ol_amount:
+            return_code = 1
+            continue
+        
+        #### check order_lines correctly updated
+        # print()
+        # order_lines = session.execute(f"""
+        #   SELECT * FROM order_line WHERE ol_w_id=%s AND ol_d_id=%s AND ol_o_id=%s;""",
+        #   (w_id, d_id, order.o_id))
+        # for r in order_lines:
+        #   print(r)
+
+        #### update customer's C_BALANCE, C_DELIVERY_CNT via drop and insert
+        # not expected to fail. `order` exists at this point.
+        customer = session.execute(SimpleStatement(f"""
+            SELECT * FROM customer 
+            WHERE c_w_id={w_id} 
+            and c_d_id={d_id} 
+            and c_id={order.o_c_id};"""))
+        if not customer:
+            return_code = 1
+            continue
+        customer = customer[0]
+        # print(customer)
+
+        ts = int(time.time() * 10e6)
+        batch = BatchStatement()
+        batch.add(SimpleStatement(f"""
+            DELETE FROM customer 
+            USING TIMESTAMP {ts}
+            WHERE c_w_id={w_id} 
+            and c_d_id={d_id} 
+            and c_id={order.o_c_id};"""))
+
+        batch.add(SimpleStatement(f"""
+            INSERT INTO customer (c_w_id, 
+                                c_d_id, 
+                                c_id, 
+                                c_balance, 
+                                c_city, 
+                                c_credit, 
+                                c_credit_lim, 
+                                c_d_name, 
+                                c_data, 
+                                c_delivery_cnt,
+                                c_discount,
+                                c_first,
+                                c_last,
+                                c_middle,
+                                c_payment_cnt,
+                                c_phone,
+                                c_since,
+                                c_state,
+                                c_street_1,
+                                c_street_2,
+                                c_w_name,
+                                c_ytd_payment,
+                                c_zip) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        USING TIMESTAMP %s;"""), 
+                            (customer.c_w_id, 
+                                customer.c_d_id, 
+                                customer.c_id, 
+                                customer.c_balance + ol_amount_total, 
+                                customer.c_city, 
+                                customer.c_credit, 
+                                customer.c_credit_lim, 
+                                customer.c_d_name, 
+                                customer.c_data, 
+                                customer.c_delivery_cnt + 1,
+                                customer.c_discount,
+                                customer.c_first,
+                                customer.c_last,
+                                customer.c_middle,
+                                customer.c_payment_cnt,
+                                customer.c_phone,
+                                customer.c_since,
+                                customer.c_state,
+                                customer.c_street_1,
+                                customer.c_street_2,
+                                customer.c_w_name,
+                                customer.c_ytd_payment,
+                                customer.c_zip,
+                                ts + 1))
+        
+        session.execute(batch)
+
+        #### customer's C_BALANCE duplicated in top_balance table
+        ts = int(time.time() * 10e6)
+        batch = BatchStatement()
+        batch.add(SimpleStatement(f"""
+            DELETE FROM top_balance 
+            USING TIMESTAMP {ts}
+            WHERE c_w_id={customer.c_w_id} 
+            and c_d_id={customer.c_d_id} 
+            and c_balance={customer.c_balance} 
+            and c_id={customer.c_id};"""))
+
+        batch.add(SimpleStatement(f"""
+            INSERT INTO top_balance (c_w_id,
+                                    c_d_id,
+                                    c_balance,
+                                    c_id,
+                                    c_d_name,
+                                    c_first,
+                                    c_last,
+                                    c_middle,
+                                    c_w_name) 
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        USING TIMESTAMP %s;"""), 
+                            (customer.c_w_id, 
                             customer.c_d_id, 
+                            customer.c_balance + ol_amount_total,
                             customer.c_id, 
-                            customer.c_balance + ol_amount_total, 
-                            customer.c_city, 
-                            customer.c_credit, 
-                            customer.c_credit_lim, 
                             customer.c_d_name, 
-                            customer.c_data, 
-                            customer.c_delivery_cnt + 1,
-                            customer.c_discount,
                             customer.c_first,
                             customer.c_last,
                             customer.c_middle,
-                            customer.c_payment_cnt,
-                            customer.c_phone,
-                            customer.c_since,
-                            customer.c_state,
-                            customer.c_street_1,
-                            customer.c_street_2,
                             customer.c_w_name,
-                            customer.c_ytd_payment,
-                            customer.c_zip,
                             ts + 1))
-      
-      session.execute(batch)
+        session.execute(batch)
 
-      #### customer's C_BALANCE duplicated in top_balance table
-      ts = int(time.time() * 10e6)
-      batch = BatchStatement()
-      batch.add(SimpleStatement(f"""
-        DELETE FROM top_balance 
-        USING TIMESTAMP {ts}
-        WHERE c_w_id={customer.c_w_id} 
-        and c_d_id={customer.c_d_id} 
-        and c_balance={customer.c_balance} 
-        and c_id={customer.c_id};"""))
-
-      batch.add(SimpleStatement(f"""
-        INSERT INTO top_balance (c_w_id,
-                                 c_d_id,
-                                 c_balance,
-                                 c_id,
-                                 c_d_name,
-                                 c_first,
-                                 c_last,
-                                 c_middle,
-                                 c_w_name) 
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    USING TIMESTAMP %s;"""), 
-                          (customer.c_w_id, 
-                           customer.c_d_id, 
-                           customer.c_balance + ol_amount_total,
-                           customer.c_id, 
-                           customer.c_d_name, 
-                           customer.c_first,
-                           customer.c_last,
-                           customer.c_middle,
-                           customer.c_w_name,
-                           ts + 1))
-      session.execute(batch)
-
-      #### check customer updated
-      # customer = session.execute(SimpleStatement(f"""SELECT * FROM customer WHERE c_w_id={w_id} and c_d_id={d_id} and c_id={order.o_c_id};"""))[0]
-      # print(customer)
+        #### check customer updated
+        # customer = session.execute(SimpleStatement(f"""SELECT * FROM customer WHERE c_w_id={w_id} and c_d_id={d_id} and c_id={order.o_c_id};"""))[0]
+        # print(customer)
 
 
-      #### O_CARRIER_ID duplicated in order_status table
-      # order_status_before = session.execute(f"""
-      #   SELECT * FROM order_status where O_W_ID=%s and O_D_ID=%s and O_C_ID=%s and O_ID=%s;""",
-      #   (w_id, d_id, order.o_c_id, order.o_id))[0]
-      # print(order_status_before)
-      # assert order_status_before.o_carrier_id == -1, f"Inconsistency detected? Trying to update null order_status carrier_id but it's already non-null" # ask
+        #### O_CARRIER_ID duplicated in order_status table
+        # order_status_before = session.execute(f"""
+        #   SELECT * FROM order_status where O_W_ID=%s and O_D_ID=%s and O_C_ID=%s and O_ID=%s;""",
+        #   (w_id, d_id, order.o_c_id, order.o_id))[0]
+        # print(order_status_before)
+        # assert order_status_before.o_carrier_id == -1, f"Inconsistency detected? Trying to update null order_status carrier_id but it's already non-null" # ask
 
-      # Actual UPDATE query. The ones before and after are for checking while developing
-      session.execute(f"""
-        UPDATE order_status 
-        SET o_carrier_id=%s 
-        where O_W_ID=%s 
-        and O_D_ID=%s 
-        and O_C_ID=%s 
-        and O_ID=%s;""",
-        (new_carrier_id, w_id, d_id, order.o_c_id, order.o_id))
+        # Actual UPDATE query. The ones before and after are for checking while developing
+        session.execute(f"""
+            UPDATE order_status 
+            SET o_carrier_id=%s 
+            where O_W_ID=%s 
+            and O_D_ID=%s 
+            and O_C_ID=%s 
+            and O_ID=%s;""",
+            (new_carrier_id, w_id, d_id, order.o_c_id, order.o_id))
 
-      # order_status_after = session.execute(f"""
-      #   SELECT * FROM order_status where O_W_ID=%s and O_D_ID=%s and O_C_ID=%s and O_ID=%s;""",
-      #   (w_id, d_id, order.o_c_id, order.o_id))[0]
-      # print(order_status_after)
+        # order_status_after = session.execute(f"""
+        #   SELECT * FROM order_status where O_W_ID=%s and O_D_ID=%s and O_C_ID=%s and O_ID=%s;""",
+        #   (w_id, d_id, order.o_c_id, order.o_id))[0]
+        # print(order_status_after)
 
     return return_code
     

--- a/cassandra/transactions/t3.py
+++ b/cassandra/transactions/t3.py
@@ -137,9 +137,8 @@ def execute_t3(session, args_arr):
 
       # note: order_lines is an iterator and will be exhausted. Only one iteration is allowed without duplicating it.
       ol_amount_total = Decimal(0)
+      none_ol_amount = False
       for r in order_lines:
-        ol_amount_total += r.ol_amount
-
         session.execute(f"""
           UPDATE order_line 
           SET ol_delivery_d=toTimestamp(Now())
@@ -150,6 +149,17 @@ def execute_t3(session, args_arr):
             AND OL_NUMBER=%s
             AND OL_C_ID=%s;""",
           (r.ol_w_id, r.ol_d_id, r.ol_o_id, r.ol_quantity, r.ol_number, r.ol_c_id))
+
+        if r.ol_amount is None:
+            none_ol_amount = True
+            # try to update as many order_lines as possible
+            continue
+        ol_amount_total += r.ol_amount
+
+
+      if none_ol_amount:
+          return_code = 1
+          continue
         
       #### check order_lines correctly updated
       # print()


### PR DESCRIPTION
- `t2.py`: remove checking of response from UPDATE query which is always `None`. Used to be a conditional update which had a return value but that was changed to be non-conditional UPDATE.
- Add timestamps to all Batch statements so that execution order within each batch will have the DELETE before the INSERT. Net effect should be that said row is updated atomically.
- `t3.py`: Handle case where `r.ol_amount` could return `None`
- Fix inconsistent indentation--was using mix of 2 / 4 spaces